### PR TITLE
Missing Dockerfile for '/backend'

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -22,6 +22,4 @@ yarn-error.log
 /.vscode
 /.zed
 
-
-Dockerfile
 docker-compose.yml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,25 @@
+# backend/Dockerfile
+FROM php:8.2-cli
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    unzip \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    zip \
+    libzip-dev \
+    && docker-php-ext-install pdo_mysql zip
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+COPY . .
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+CMD ["/entrypoint.sh"]


### PR DESCRIPTION
## **Pull Request : Restore backend Dockerfile**

### **Titre PR :**

Restore missing Dockerfile for backend

### **Description :**

Le Dockerfile du backend avait été **accidentellement ignoré** à cause du `.gitignore`. Cette PR le restaure dans le dépôt et s’assure que le backend peut être construit via Docker sans problème.

---

## **Commit : Restore backend Dockerfile | FIX**

**Changements :**

1. Suppression ou modification du `.gitignore` pour permettre l’ajout du Dockerfile backend :

```diff
- Dockerfile
```

2. Ajout du Dockerfile backend dans le dépôt :

```dockerfile
# backend/Dockerfile
FROM php:8.2-cli

RUN apt-get update && apt-get install -y \
    git \
    curl \
    unzip \
    libpng-dev \
    libonig-dev \
    libxml2-dev \
    zip \
    libzip-dev \
    && docker-php-ext-install pdo_mysql zip

COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

WORKDIR /var/www/html

COPY . .

COPY entrypoint.sh /entrypoint.sh

RUN chmod +x /entrypoint.sh

CMD ["/entrypoint.sh"]

```

✅ Avec ce commit :

* Le backend peut être construit avec Docker.
* Le fichier `Dockerfile` est suivi par Git.
* L’entrypoint gère automatiquement `key:generate`, `migrate` et `serve`.

---

### **Testing Instructions**

1. Vérifier que le backend peut se construire et démarrer :

```bash
docker-compose build backend
docker-compose up backend
```

2. Le serveur Laravel doit être accessible sur `localhost:8000`.